### PR TITLE
Fix overriding nullable type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -76,6 +76,14 @@ parameters:
 			path: src/Domain/Models/Actions/FindModels.php
 
 		-
+			message: """
+				#^Call to deprecated method getName\\(\\) of class Doctrine\\\\DBAL\\\\Types\\\\Type\\:
+				this method will be removed in Doctrine DBAL 4\\.0\\.$#
+			"""
+			count: 1
+			path: src/Domain/Models/Actions/ResolveModelAttributes.php
+
+		-
 			message: "#^PHPDoc tag @var contains generic class Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\Relation but does not specify its types\\: TRelatedModel$#"
 			count: 1
 			path: src/Domain/Models/Actions/ResolveModelRelations.php

--- a/src/Domain/Models/Actions/ApplyAttributeOverrides.php
+++ b/src/Domain/Models/Actions/ApplyAttributeOverrides.php
@@ -24,6 +24,7 @@ class ApplyAttributeOverrides implements ModelResolver
             $attribute = $model->attributes->findByName($name);
             if ($attribute !== null) {
                 $attribute->setType($this->formatTypes($type));
+                $attribute->nullable = Str::startsWith($type, '?');
             }
 
             $relation = $model->relations->findByName($name);

--- a/tests/Feature/AliasesCommandTest.php
+++ b/tests/Feature/AliasesCommandTest.php
@@ -31,6 +31,9 @@ class AliasesCommandTest extends TestCase
         if (config('app.aliases.RateLimiter') === null) {
             AliasLoader::getInstance(['RateLimiter' => \Illuminate\Support\Facades\RateLimiter::class]);
         }
+        if (config('app.aliases.Vite') === null) {
+            AliasLoader::getInstance(['Vite' => \Illuminate\Support\Facades\Vite::class]);
+        }
 
         config([
             'next-ide-helper.aliases' => [

--- a/tests/Feature/ModelsCommandTest.php
+++ b/tests/Feature/ModelsCommandTest.php
@@ -39,6 +39,9 @@ class ModelsCommandTest extends TestCase
                 'directories' => [$this->fixturePath()],
                 'file_name' => $this->fixturePath() . '/_ide_models.php',
                 'overrides' => [
+                    User::class => [
+                        'city' => 'string',
+                    ],
                     Post::class => [
                         'likes' => 'int',
                         'address' => '?' . Address::class,
@@ -100,11 +103,6 @@ class ModelsCommandTest extends TestCase
         $this->assertFileEquals(
             $this->expectedPath('PostLarastan.stub'),
             $this->fixturePath('Blog/Post.php')
-        );
-
-        $this->assertFileEquals(
-            $this->expectedPath('User.stub'),
-            $this->fixturePath('User.php')
         );
 
         $this->assertFileEquals(

--- a/tests/expected/User.stub
+++ b/tests/expected/User.stub
@@ -23,7 +23,7 @@ use Soyhuce\NextIdeHelper\Tests\Fixtures\Blog\Post;
  * @property \Illuminate\Support\Carbon $updated_at
  * @property string $screamed_email
  * @property \Soyhuce\NextIdeHelper\Tests\Fixtures\Address|null $shipping_address
- * @property-read string|null $city
+ * @property-read string $city
  * @property-write string $new_password
  * @property-read \Soyhuce\NextIdeHelper\Tests\Fixtures\Blog\PostCollection<int, \Soyhuce\NextIdeHelper\Tests\Fixtures\Blog\Post> $laravelPosts
  * @property-read \Soyhuce\NextIdeHelper\Tests\Fixtures\Blog\PostCollection<int, \Soyhuce\NextIdeHelper\Tests\Fixtures\Blog\Post> $posts

--- a/tests/expected/_ide_aliases.stub
+++ b/tests/expected/_ide_aliases.stub
@@ -157,4 +157,8 @@ namespace
     class View extends \Illuminate\Support\Facades\View
     {
     }
+
+    class Vite extends \Illuminate\Support\Facades\Vite
+    {
+    }
 }


### PR DESCRIPTION
Fix overriding nullable type.

When `$user->city` is `?int`, overriding with `'city' => 'string'` should mark `city` as `string`, not `?string`