### PR TITLE
Added immutable dates to type caster

### DIFF
--- a/src/Domain/Models/AttributeTypeCaster.php
+++ b/src/Domain/Models/AttributeTypeCaster.php
@@ -105,6 +105,8 @@ class AttributeTypeCaster
             case 'date':
             case 'datetime':
             case 'custom_datetime':
+            case 'immutable_date':
+            case 'immutable_datetime':
                 return $this->dateClass();
         }
 


### PR DESCRIPTION
I was missing the `immutable_date` and `immutable_datetime` [casts](https://laravel.com/docs/10.x/eloquent-mutators#attribute-casting).