### PR TITLE
Link sources for macros and model scopes

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" backupGlobals="false"
          bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false"
          executionOrder="random" failOnWarning="true" failOnRisky="true" failOnEmptyTestSuite="true"
-         beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+         beStrictAboutOutputDuringTests="true" cacheDirectory="phpunit" backupStaticProperties="false">
     <testsuites>
         <testsuite name="Soyhuce Test Suite">
             <directory>tests</directory>

--- a/src/Domain/Macros/Output/MacrosHelperFile.php
+++ b/src/Domain/Macros/Output/MacrosHelperFile.php
@@ -21,7 +21,13 @@ class MacrosHelperFile
         foreach ($this->macros() as $name => $macro) {
             $macro = new ReflectionFunction($macro);
 
-            $class->addDocTag(Method::fromFunction($name, $macro)->toDocTag());
+            $method = Method::fromFunction($name, $macro);
+            $class->addDocTag($method->toDocTag());
+
+            $link = $method->toLinkTag();
+            if ($link !== null) {
+                $class->addDocTag($link);
+            }
         }
 
         $constructor = $this->constructor($this->class);

--- a/src/Domain/Models/Actions/ResolveModelScopes.php
+++ b/src/Domain/Models/Actions/ResolveModelScopes.php
@@ -19,7 +19,9 @@ class ResolveModelScopes implements ModelResolver
 
         /** @var ReflectionMethod $method */
         foreach ($methods as $method) {
-            $scope = Method::new($this->methodName($method->getName()));
+            $scope = Method::new($this->methodName($method->getName()))
+                ->source(FunctionReflection::source($method))
+                ->line(FunctionReflection::line($method));
 
             $parameters = array_slice(FunctionReflection::parameterList($method), 1);
             $scope->parameters(implode(', ', $parameters));

--- a/src/Domain/Models/Output/QueryBuilderDocBlock.php
+++ b/src/Domain/Models/Output/QueryBuilderDocBlock.php
@@ -100,12 +100,10 @@ class QueryBuilderDocBlock extends DocBlock implements Renderer
     private function scopeMethods(): Collection
     {
         return collect($this->model->scopes)
-            ->map(fn (Method $scope): string => sprintf(
-                ' * @method %s %s(%s)',
-                $this->model->queryBuilder->fqcn,
-                $scope->name,
-                $scope->parameters
-            ));
+            ->flatMap(fn (Method $scope): array => array_filter([
+                $scope->returnType($this->model->queryBuilder->fqcn)->toDocTag(),
+                $scope->toLinkTag(),
+            ]));
     }
 
     /**

--- a/src/Entities/Method.php
+++ b/src/Entities/Method.php
@@ -138,7 +138,7 @@ class Method
 
         return sprintf(
             ' * @see project://%s L%d',
-            Str::after($this->source, base_path().DIRECTORY_SEPARATOR),
+            Str::after($this->source, base_path() . DIRECTORY_SEPARATOR),
             $this->line
         );
     }

--- a/src/Support/Reflection/FunctionReflection.php
+++ b/src/Support/Reflection/FunctionReflection.php
@@ -4,7 +4,6 @@ namespace Soyhuce\NextIdeHelper\Support\Reflection;
 
 use Illuminate\Support\Str;
 use ReflectionFunctionAbstract;
-use function array_slice;
 
 class FunctionReflection
 {
@@ -67,38 +66,23 @@ class FunctionReflection
         return $returnType;
     }
 
-    /**
-     * @return array<string>
-     */
-    public static function bodyLines(ReflectionFunctionAbstract $function): array
+    public static function source(ReflectionFunctionAbstract $function): ?string
     {
         $filename = $function->getFileName();
         if ($filename === false) {
-            return [];
+            return '';
         }
 
-        $file = file($filename);
-        if ($file === false) {
-            return [];
+        return $filename;
+    }
+
+    public static function line(ReflectionFunctionAbstract $function): ?int
+    {
+        $line = $function->getStartLine();
+        if ($line === false) {
+            return null;
         }
 
-        $startLine = $function->getStartLine();
-        $endLine = $function->getEndLine();
-        $length = $endLine - $startLine - 1;
-        if ($startLine === false || $endLine === false || $length < 1) {
-            return [];
-        }
-
-        $lines = collect(array_slice($file, $startLine, $length));
-        $lastLine = $lines->last();
-        if ($lastLine === null) {
-            return [];
-        }
-
-        $spaces = max(Str::length($lastLine) - Str::length(ltrim($lastLine, ' ')) - 4, 0);
-
-        return $lines->map(
-            static fn (string $line) => Str::of($line)->substr($spaces)->rtrim(PHP_EOL)->toString()
-        )->toArray();
+        return $line;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,6 +23,8 @@ abstract class TestCase extends Orchestra
         if (in_array(ResetsFixtures::class, class_uses_recursive($this), true)) {
             $this->bootResetsFixtures();
         }
+
+        $this->app->setBasePath(realpath(__DIR__));
     }
 
     protected function getPackageProviders($app)

--- a/tests/expected/_ide_macros.stub
+++ b/tests/expected/_ide_macros.stub
@@ -4,13 +4,21 @@ namespace Soyhuce\NextIdeHelper\Tests\Fixtures\Macroable
 {
     /**
      * @method static string foo(string $bar)
+     * @see project://Feature/MacrosCommandTest.php L20
      * @method static string toLower(string $value)
+     * @see project://Fixtures/Macroable/SomeMixin.php L17
      * @method void havingVariadic(string &...$params)
+     * @see project://Fixtures/Macroable/SomeMixin.php L22
      * @method self havingSelfAsReturnType()
+     * @see project://Fixtures/Macroable/SomeMixin.php L32
      * @method void havingArrayAsDefaultValue(array $array = [1, 2, 3, ['some' => 'value']])
+     * @see project://Fixtures/Macroable/SomeMixin.php L37
      * @method mixed havingNullableMixed(mixed $value = null)
+     * @see project://Fixtures/Macroable/SomeMixin.php L44
      * @method mixed havingNullableUnionType(string|int|null $value = null)
+     * @see project://Fixtures/Macroable/SomeMixin.php L49
      * @method string|null returningNullableString()
+     * @see project://Fixtures/Macroable/SomeMixin.php L54
      */
     class SomeMacroable
     {

--- a/tests/expected/_ide_models.stub
+++ b/tests/expected/_ide_models.stub
@@ -42,6 +42,7 @@ namespace IdeHelper\Soyhuce\NextIdeHelper\Tests\Fixtures
      * @method \IdeHelper\Soyhuce\NextIdeHelper\Tests\Fixtures\__UserQuery whereCreatedAt(\Illuminate\Support\Carbon|string $value)
      * @method \IdeHelper\Soyhuce\NextIdeHelper\Tests\Fixtures\__UserQuery whereUpdatedAt(\Carbon\CarbonImmutable|string $value)
      * @method \IdeHelper\Soyhuce\NextIdeHelper\Tests\Fixtures\__UserQuery whereEmailDomain(string $domain, ?string $area = null)
+     * @see project://Fixtures/User.php L76
      * @method \Soyhuce\NextIdeHelper\Tests\Fixtures\User create(array $attributes = [])
      * @method \Illuminate\Database\Eloquent\Collection|\Soyhuce\NextIdeHelper\Tests\Fixtures\User|null find($id, array $columns = ['*'])
      * @method \Illuminate\Database\Eloquent\Collection findMany($id, array $columns = ['*'])

--- a/tests/expected/_ide_modelsLarastan.stub
+++ b/tests/expected/_ide_modelsLarastan.stub
@@ -44,6 +44,7 @@ namespace IdeHelper\Soyhuce\NextIdeHelper\Tests\Fixtures
      * @method \IdeHelper\Soyhuce\NextIdeHelper\Tests\Fixtures\__UserQuery whereCreatedAt(\Illuminate\Support\Carbon|string $value)
      * @method \IdeHelper\Soyhuce\NextIdeHelper\Tests\Fixtures\__UserQuery whereUpdatedAt(\Carbon\CarbonImmutable|string $value)
      * @method \IdeHelper\Soyhuce\NextIdeHelper\Tests\Fixtures\__UserQuery whereEmailDomain(string $domain, ?string $area = null)
+     * @see project://Fixtures/User.php L76
      * @method \Soyhuce\NextIdeHelper\Tests\Fixtures\User create(array $attributes = [])
      * @method \Illuminate\Database\Eloquent\Collection<int, \Soyhuce\NextIdeHelper\Tests\Fixtures\User>|\Soyhuce\NextIdeHelper\Tests\Fixtures\User|null find($id, array $columns = ['*'])
      * @method \Illuminate\Database\Eloquent\Collection<int, \Soyhuce\NextIdeHelper\Tests\Fixtures\User> findMany($id, array $columns = ['*'])


### PR DESCRIPTION
This allows to get a link to the source where macros and model scopes are defines

```diff
    /**
     * @method static string foo(string $bar)
+    * @see project://Feature/MacrosCommandTest.php L20
     */
```

The path is relative to `base_path()` and opens correctly the file under phpstorm. Unfortunately, it is not yet possible to open the file at the correct line.

