### PR TITLE
Add a boolean to Attribute in order to define if it is nullable in database

### DIFF
--- a/src/Domain/Models/Actions/ResolveModelAttributes.php
+++ b/src/Domain/Models/Actions/ResolveModelAttributes.php
@@ -20,6 +20,7 @@ class ResolveModelAttributes implements ModelResolver
             $attribute->inDatabase = true;
             if (!$column->getNotnull() && !$this->isLaravelTimestamp($model, $attribute)) {
                 $attribute->nullable = true;
+                $attribute->nullableInDatabase = true;
             }
 
             $model->addAttribute($typeCaster->resolve($attribute));

--- a/src/Domain/Models/Entities/Attribute.php
+++ b/src/Domain/Models/Entities/Attribute.php
@@ -18,6 +18,8 @@ class Attribute
 
     public bool $inDatabase = false;
 
+    public bool $nullableInDatabase = false;
+
     public ?string $comment = null;
 
     public function __construct(string $name, string $type)


### PR DESCRIPTION
This PR introduces `nullableInDatabase` which can be used later to determine if the attribute is nullable in database.

It can be used, for example, for some resolvers which need this information