### PR TITLE
Fixed comment for ResolveModelAttributes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,11 +61,6 @@ parameters:
 			path: src/Domain/Meta/Actions/ResolveContainerBindings.php
 
 		-
-			message: "#^Unable to resolve the template type TMapValue in call to method Illuminate\\\\Support\\\\Collection\\<string,object\\>\\:\\:map\\(\\)$#"
-			count: 1
-			path: src/Domain/Meta/Actions/ResolveContainerBindings.php
-
-		-
 			message: "#^Parameter \\#1 \\$fqcn of class Soyhuce\\\\NextIdeHelper\\\\Domain\\\\Models\\\\Entities\\\\Model constructor expects class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>, class\\-string given\\.$#"
 			count: 1
 			path: src/Domain/Models/Actions/FindModels.php

--- a/src/Domain/Models/Actions/ResolveModelAttributes.php
+++ b/src/Domain/Models/Actions/ResolveModelAttributes.php
@@ -8,7 +8,7 @@ use Soyhuce\NextIdeHelper\Domain\Models\Entities\Attribute;
 use Soyhuce\NextIdeHelper\Domain\Models\Entities\Model;
 
 /**
- * @phpstan-type Column array{name: string, type_name: string, nullable: bool}
+ * @phpstan-type Column array{name: string, type_name: string, nullable: bool, comment: string|null}
  */
 class ResolveModelAttributes implements ModelResolver
 {
@@ -18,7 +18,7 @@ class ResolveModelAttributes implements ModelResolver
         $typeCaster = new AttributeTypeCaster($model);
 
         foreach ($columns as $column) {
-            $attribute = new Attribute($column['name'], $column['type_name']);
+            $attribute = new Attribute($column['name'], $column['type_name'], $column['comment']);
             $attribute->inDatabase = true;
             if ($column['nullable'] && !$this->isLaravelTimestamp($model, $attribute)) {
                 $attribute->nullable = true;

--- a/src/Domain/Models/Entities/Attribute.php
+++ b/src/Domain/Models/Entities/Attribute.php
@@ -22,10 +22,11 @@ class Attribute
 
     public ?string $comment = null;
 
-    public function __construct(string $name, string $type)
+    public function __construct(string $name, string $type, ?string $comment = null)
     {
         $this->name = $name;
         $this->setType($type);
+        $this->comment = $comment;
         $this->nullable = false;
     }
 

--- a/tests/Feature/AliasesCommandTest.php
+++ b/tests/Feature/AliasesCommandTest.php
@@ -28,6 +28,9 @@ class AliasesCommandTest extends TestCase
         if (config('app.aliases.Schedule') === null) {
             AliasLoader::getInstance(['Schedule' => \Illuminate\Support\Facades\Schedule::class]);
         }
+        if (config('app.aliases.Context') === null) {
+            AliasLoader::getInstance(['Context' => \Illuminate\Support\Facades\Context::class]);
+        }
 
         config([
             'next-ide-helper.aliases' => [

--- a/tests/expected/_ide_aliases.stub
+++ b/tests/expected/_ide_aliases.stub
@@ -38,6 +38,10 @@ namespace
     {
     }
 
+    class Context extends \Illuminate\Support\Facades\Context
+    {
+    }
+
     class Cookie extends \Illuminate\Support\Facades\Cookie
     {
     }


### PR DESCRIPTION
Hello. I would like to fix the generation of documentation for models.

I slightly modified your code and unfortunately I can’t add tests, because `->comment()` doesn’t work for me in SQLite or I’m doing something wrong. I would be grateful for your review of the code and am ready to make improvements.  Thanks for the significant improvements to the package!

I can only show a screenshot that the documentation was indeed generated. Tested on Laravel 11 + PostgreSQL 16

<img width="482" alt="image" src="https://github.com/Soyhuce/next-ide-helper/assets/28255085/7bb503a6-dcd5-411f-af76-174c7ce05486">
