### PR TITLE
Document Carbon macros

### DIFF
--- a/src/Console/MacrosCommand.php
+++ b/src/Console/MacrosCommand.php
@@ -4,6 +4,7 @@ namespace Soyhuce\NextIdeHelper\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Facade;
 use ReflectionClass;
 use Soyhuce\NextIdeHelper\Domain\Macros\Actions\FindFacadeClasses;
@@ -53,6 +54,10 @@ class MacrosCommand extends Command
      */
     public function resolveFacadeRoot(string $facade): array
     {
+        if ($facade === Date::class) {
+            return [Date::now()::class => $facade];
+        }
+
         try {
             return [$facade::getFacadeRoot()::class => $facade];
         } catch (Throwable) {

--- a/src/Domain/Macros/Actions/FindMacroableClasses.php
+++ b/src/Domain/Macros/Actions/FindMacroableClasses.php
@@ -5,6 +5,8 @@ namespace Soyhuce\NextIdeHelper\Domain\Macros\Actions;
 use Carbon\FactoryImmutable;
 use Carbon\Traits\Macro as CarbonMacro;
 use Composer\ClassMapGenerator\ClassMapGenerator;
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable as IlluminateMacroable;
 use ReflectionClass;
@@ -76,6 +78,21 @@ class FindMacroableClasses
             return false;
         }
 
+        if (InstalledVersions::satisfies(new VersionParser(), 'nesbot/carbon', '^2.0')) {
+            $reflectionClass = new ReflectionClass($class);
+
+            if (!$reflectionClass->hasProperty('globalMacros')) {
+                return false;
+            }
+
+            $property = $reflectionClass->getProperty('globalMacros');
+
+            if (empty($property->getValue())) {
+                return false;
+            }
+
+            return true;
+        }
         $macros = FactoryImmutable::getDefaultInstance()->getSettings()['macros'] ?? [];
 
         if (empty($macros)) {

--- a/src/Domain/Macros/Actions/FindMacroableClasses.php
+++ b/src/Domain/Macros/Actions/FindMacroableClasses.php
@@ -93,6 +93,7 @@ class FindMacroableClasses
 
             return true;
         }
+
         $macros = FactoryImmutable::getDefaultInstance()->getSettings()['macros'] ?? [];
 
         if (empty($macros)) {

--- a/src/Domain/Macros/Output/MacrosHelperFile.php
+++ b/src/Domain/Macros/Output/MacrosHelperFile.php
@@ -5,6 +5,8 @@ namespace Soyhuce\NextIdeHelper\Domain\Macros\Output;
 use Carbon\FactoryImmutable;
 use Carbon\Traits\Macro as CarbonMacro;
 use Closure;
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Illuminate\Support\Traits\Macroable as IlluminateMacroable;
 use ReflectionClass;
 use ReflectionFunction;
@@ -66,9 +68,7 @@ class MacrosHelperFile
      */
     private function illuminateMacros(): array
     {
-        $property = $this->class->getProperty('macros');
-
-        return $property->getValue();
+        return $this->class->getProperty('macros')->getValue();
     }
 
     /**
@@ -76,6 +76,10 @@ class MacrosHelperFile
      */
     private function carbonMacros(): array
     {
+        if (InstalledVersions::satisfies(new VersionParser(), 'nesbot/carbon', '^2.0')) {
+            return $this->class->getProperty('globalMacros')->getValue();
+        }
+
         return FactoryImmutable::getDefaultInstance()->getSettings()['macros'];
     }
 

--- a/src/Domain/Macros/Output/MacrosHelperFile.php
+++ b/src/Domain/Macros/Output/MacrosHelperFile.php
@@ -2,11 +2,15 @@
 
 namespace Soyhuce\NextIdeHelper\Domain\Macros\Output;
 
+use Carbon\FactoryImmutable;
+use Carbon\Traits\Macro as CarbonMacro;
 use Closure;
+use Illuminate\Support\Traits\Macroable as IlluminateMacroable;
 use ReflectionClass;
 use ReflectionFunction;
 use Soyhuce\NextIdeHelper\Entities\Method;
 use Soyhuce\NextIdeHelper\Support\Output\IdeHelperFile;
+use function in_array;
 
 class MacrosHelperFile
 {
@@ -46,10 +50,33 @@ class MacrosHelperFile
      */
     private function macros(): array
     {
+        if (in_array(IlluminateMacroable::class, class_uses_recursive($this->class->getName()), true)) {
+            return $this->illuminateMacros();
+        }
+
+        if (in_array(CarbonMacro::class, class_uses_recursive($this->class->getName()), true)) {
+            return $this->carbonMacros();
+        }
+
+        return [];
+    }
+
+    /**
+     * @return array<string, Closure>
+     */
+    private function illuminateMacros(): array
+    {
         $property = $this->class->getProperty('macros');
-        $property->setAccessible(true);
 
         return $property->getValue();
+    }
+
+    /**
+     * @return array<string, Closure>
+     */
+    private function carbonMacros(): array
+    {
+        return FactoryImmutable::getDefaultInstance()->getSettings()['macros'];
     }
 
     private function constructor(ReflectionClass $class): ?Method

--- a/src/Domain/Models/Entities/Relation.php
+++ b/src/Domain/Models/Entities/Relation.php
@@ -81,7 +81,6 @@ class Relation
         }
 
         $foreignKey = $object->getProperty('foreignKey');
-        $foreignKey->setAccessible(true);
 
         $attribute = $this->parent->attributes->findByName($foreignKey->getValue($relation));
         if ($attribute === null) {

--- a/tests/.pest/snapshots/Feature/MacrosCommandTest/the_command_is_successful.snap
+++ b/tests/.pest/snapshots/Feature/MacrosCommandTest/the_command_is_successful.snap
@@ -4,7 +4,7 @@ namespace Illuminate\Support
 {
     /**
      * @method string testDateMacro()
-     * @see project://Feature/MacrosCommandTest.php L18
+     * @see project://Feature/MacrosCommandTest.php L19
      */
     class Carbon
     {
@@ -26,7 +26,7 @@ namespace Illuminate\Support\Facades
 {
     /**
      * @method static string testDateMacro()
-     * @see project://Feature/MacrosCommandTest.php L18
+     * @see project://Feature/MacrosCommandTest.php L19
      */
     class Date
     {

--- a/tests/.pest/snapshots/Feature/MacrosCommandTest/the_command_is_successful.snap
+++ b/tests/.pest/snapshots/Feature/MacrosCommandTest/the_command_is_successful.snap
@@ -1,10 +1,43 @@
 <?php
 
+namespace Illuminate\Support
+{
+    /**
+     * @method string testDateMacro()
+     * @see project://Feature/MacrosCommandTest.php L17
+     */
+    class Carbon
+    {
+        /**
+         * Create a new Carbon instance.
+         *
+         * Please see the testing aids section (specifically static::setTestNow())
+         * for more on the possibility of this constructor returning a test instance.
+         *
+         * @throws InvalidFormatException
+        */
+        public function __construct(\DateTimeInterface|\Carbon\WeekDay|\Carbon\Month|string|int|float|null $time = null, \DateTimeZone|string|int|null $timezone = null)
+        {
+        }
+    }
+}
+
+namespace Illuminate\Support\Facades
+{
+    /**
+     * @method static string testDateMacro()
+     * @see project://Feature/MacrosCommandTest.php L17
+     */
+    class Date
+    {
+    }
+}
+
 namespace Soyhuce\NextIdeHelper\Tests\Fixtures\Macroable
 {
     /**
      * @method static string foo(string $bar)
-     * @see project://Feature/MacrosCommandTest.php L10
+     * @see project://Feature/MacrosCommandTest.php L11
      * @method static string toLower(string $value)
      * @see project://Fixtures/Macroable/SomeMixin.php L17
      * @method static void havingVariadic(string &...$params)
@@ -20,7 +53,7 @@ namespace Soyhuce\NextIdeHelper\Tests\Fixtures\Macroable
      * @method static string|null returningNullableString()
      * @see project://Fixtures/Macroable/SomeMixin.php L54
      * @method static string testFacade()
-     * @see project://Feature/MacrosCommandTest.php L14
+     * @see project://Feature/MacrosCommandTest.php L15
      */
     class SomeFacade
     {
@@ -28,7 +61,7 @@ namespace Soyhuce\NextIdeHelper\Tests\Fixtures\Macroable
 
     /**
      * @method static string foo(string $bar)
-     * @see project://Feature/MacrosCommandTest.php L10
+     * @see project://Feature/MacrosCommandTest.php L11
      * @method static string toLower(string $value)
      * @see project://Fixtures/Macroable/SomeMixin.php L17
      * @method void havingVariadic(string &...$params)
@@ -44,7 +77,7 @@ namespace Soyhuce\NextIdeHelper\Tests\Fixtures\Macroable
      * @method string|null returningNullableString()
      * @see project://Fixtures/Macroable/SomeMixin.php L54
      * @method string testFacade()
-     * @see project://Feature/MacrosCommandTest.php L14
+     * @see project://Feature/MacrosCommandTest.php L15
      */
     class SomeMacroable
     {

--- a/tests/.pest/snapshots/Feature/MacrosCommandTest/the_command_is_successful_with_carbon_2.snap
+++ b/tests/.pest/snapshots/Feature/MacrosCommandTest/the_command_is_successful_with_carbon_2.snap
@@ -14,9 +14,12 @@ namespace Illuminate\Support
          * Please see the testing aids section (specifically static::setTestNow())
          * for more on the possibility of this constructor returning a test instance.
          *
+         * @param DateTimeInterface|string|null $time
+         * @param DateTimeZone|string|null      $tz
+         *
          * @throws InvalidFormatException
         */
-        public function __construct(\DateTimeInterface|\Carbon\WeekDay|\Carbon\Month|string|int|float|null $time = null, \DateTimeZone|string|int|null $timezone = null)
+        public function __construct($time = null, $tz = null)
         {
         }
     }

--- a/tests/.pest/snapshots/Feature/MacrosCommandTest/the_command_is_successful_with_carbon_2.snap
+++ b/tests/.pest/snapshots/Feature/MacrosCommandTest/the_command_is_successful_with_carbon_2.snap
@@ -4,7 +4,7 @@ namespace Illuminate\Support
 {
     /**
      * @method string testDateMacro()
-     * @see project://Feature/MacrosCommandTest.php L18
+     * @see project://Feature/MacrosCommandTest.php L19
      */
     class Carbon
     {
@@ -29,7 +29,7 @@ namespace Illuminate\Support\Facades
 {
     /**
      * @method static string testDateMacro()
-     * @see project://Feature/MacrosCommandTest.php L18
+     * @see project://Feature/MacrosCommandTest.php L19
      */
     class Date
     {

--- a/tests/Feature/MacrosCommandTest.php
+++ b/tests/Feature/MacrosCommandTest.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Soyhuce\NextIdeHelper\Tests\Fixtures\Macroable\SomeFacade;
@@ -12,6 +13,8 @@ beforeEach(function (): void {
     SomeMacroable::mixin(new SomeMixin());
 
     SomeFacade::macro('testFacade', fn (): string => 'foo');
+
+    Date::macro('testDateMacro', fn (): string => 'bar');
 });
 
 afterEach(function (): void {
@@ -21,7 +24,10 @@ afterEach(function (): void {
 test('the command is successful', function (): void {
     config([
         'next-ide-helper.macros' => [
-            'directories' => [$this->fixturePath('Macroable')],
+            'directories' => [
+                $this->fixturePath('Macroable'),
+                __DIR__ . '/../../vendor/laravel/framework/src/Illuminate/Support',
+            ],
             'file_name' => $this->fixturePath() . '/_ide_macros.php',
         ],
     ]);

--- a/tests/Feature/MacrosCommandTest.php
+++ b/tests/Feature/MacrosCommandTest.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
@@ -36,4 +38,21 @@ test('the command is successful', function (): void {
         ->assertExitCode(0);
 
     expect($this->fixtureFile('_ide_macros.php'))->toMatchSnapshot();
-});
+})->skip(!InstalledVersions::satisfies(new VersionParser(), 'nesbot/carbon', '^3.0'));
+
+test('the command is successful with carbon 2', function (): void {
+    config([
+        'next-ide-helper.macros' => [
+            'directories' => [
+                $this->fixturePath('Macroable'),
+                __DIR__ . '/../../vendor/laravel/framework/src/Illuminate/Support',
+            ],
+            'file_name' => $this->fixturePath() . '/_ide_macros.php',
+        ],
+    ]);
+
+    $this->artisan('next-ide-helper:macros')
+        ->assertExitCode(0);
+
+    expect($this->fixtureFile('_ide_macros.php'))->toMatchSnapshot();
+})->skip(!InstalledVersions::satisfies(new VersionParser(), 'nesbot/carbon', '^2.0'));


### PR DESCRIPTION
This PR adds documentation of Carbon macros defined by `Illuminate\Support\Facades\Date::macro` as described in #146 