### PR TITLE
Support more casts

### DIFF
--- a/src/Domain/Models/Output/Generics.php
+++ b/src/Domain/Models/Output/Generics.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\NextIdeHelper\Domain\Models\Output;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+
+class Generics
+{
+    public static function isEnabled(): bool
+    {
+        return Config::boolean('next-ide-helper.models.larastan_friendly', false);
+    }
+
+    public static function get(string $class, string $type): string
+    {
+        if (!self::isEnabled()) {
+            return $class;
+        }
+
+        if (!Str::startsWith($type, '<')) {
+            $type = "<{$type}>";
+        }
+
+        return $class . $type;
+    }
+}

--- a/src/Domain/Models/Output/ModelDocBlock.php
+++ b/src/Domain/Models/Output/ModelDocBlock.php
@@ -149,10 +149,7 @@ class ModelDocBlock extends DocBlock implements Amender, Renderer
             return null;
         }
 
-        $type = $this->model->queryBuilder->fqcn;
-        if ($this->larastanFriendly()) {
-            $type .= "<{$this->model->fqcn}>";
-        }
+        $type = Generics::get($this->model->queryBuilder->fqcn, $this->model->fqcn);
 
         return " * @method static {$type} query()";
     }
@@ -163,10 +160,7 @@ class ModelDocBlock extends DocBlock implements Amender, Renderer
             return null;
         }
 
-        $type = $this->model->collection->fqcn;
-        if ($this->larastanFriendly()) {
-            $type .= "<int, {$this->model->fqcn}>";
-        }
+        $type = Generics::get($this->model->collection->fqcn, "<int, {$this->model->fqcn}>");
 
         return " * @method static {$type} all(array|mixed \$columns = ['*'])";
     }
@@ -177,13 +171,7 @@ class ModelDocBlock extends DocBlock implements Amender, Renderer
             return null;
         }
 
-        $mixin = " * @mixin {$this->model->queryBuilder->fqcn}";
-
-        if ($this->larastanFriendly()) {
-            $mixin .= "<{$this->model->fqcn}>";
-        }
-
-        return $mixin;
+        return ' * @mixin ' . Generics::get($this->model->queryBuilder->fqcn, $this->model->fqcn);
     }
 
     private function factory(): ?string
@@ -206,10 +194,5 @@ class ModelDocBlock extends DocBlock implements Amender, Renderer
     private function wants(int $flag): bool
     {
         return ($this->flags & $flag) !== 0;
-    }
-
-    private function larastanFriendly(): bool
-    {
-        return (bool) config('next-ide-helper.models.larastan_friendly', false);
     }
 }

--- a/src/Domain/Models/Output/QueryBuilderDocBlock.php
+++ b/src/Domain/Models/Output/QueryBuilderDocBlock.php
@@ -47,7 +47,7 @@ class QueryBuilderDocBlock extends DocBlock implements Renderer
                 fn (Collection $collection) => $collection->merge($this->softDeletesMethods())
             )
             ->when(
-                $this->larastanFriendly(),
+                Generics::isEnabled(),
                 fn (Collection $collection) => $collection
                     ->merge($this->templateBlock())
             )
@@ -112,11 +112,7 @@ class QueryBuilderDocBlock extends DocBlock implements Renderer
     private function resultMethods(): Collection
     {
         $model = $this->model->fqcn;
-        $collection = $this->model->collection->fqcn;
-
-        if ($this->larastanFriendly()) {
-            $collection .= "<int, {$this->model->fqcn}>";
-        }
+        $collection = Generics::get($this->model->collection->fqcn, "<int, {$this->model->fqcn}>");
 
         return Collection::make([
             "{$model} create(array \$attributes = [])",
@@ -162,10 +158,5 @@ class QueryBuilderDocBlock extends DocBlock implements Renderer
             " * @template TModelClass of {$this->model->fqcn}",
             ' * @extends \\Illuminate\\Database\\Eloquent\\Builder<TModelClass>',
         ]);
-    }
-
-    private function larastanFriendly(): bool
-    {
-        return (bool) config('next-ide-helper.models.larastan_friendly', false);
     }
 }

--- a/tests/.pest/snapshots/Feature/ModelsCommandTest/the_command_is_successful_with_larastan_friendly_comments.snap
+++ b/tests/.pest/snapshots/Feature/ModelsCommandTest/the_command_is_successful_with_larastan_friendly_comments.snap
@@ -18,7 +18,7 @@ use Soyhuce\NextIdeHelper\Tests\Fixtures\User;
  * @property int $user_id
  * @property string $likes
  * @property string|null $address
- * @property array|null $metas
+ * @property array<array-key, mixed>|null $metas
  * @property \Illuminate\Support\Carbon $created_at
  * @property \Illuminate\Support\Carbon $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at

--- a/tests/.pest/snapshots/Feature/ModelsCommandTest/the_command_is_successful_with_larastan_friendly_comments__2.snap
+++ b/tests/.pest/snapshots/Feature/ModelsCommandTest/the_command_is_successful_with_larastan_friendly_comments__2.snap
@@ -14,7 +14,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * @property \Illuminate\Support\Carbon $updated_at
  * @property \Illuminate\Support\Carbon $datetime
  * @property \Illuminate\Support\Carbon $date
- * @property array $encrypted_array
+ * @property array<array-key, mixed> $encrypted_array
  * @property mixed $encrypted
  * @property-read mixed $commentable
  */

--- a/tests/.pest/snapshots/Feature/ModelsCommandTest/the_command_is_successful_with_larastan_friendly_comments__3.snap
+++ b/tests/.pest/snapshots/Feature/ModelsCommandTest/the_command_is_successful_with_larastan_friendly_comments__3.snap
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Builder;
  * @method $this whereUserId(int|string $value)
  * @method $this whereLikes(string $value)
  * @method $this whereAddress(string|null $value)
- * @method $this whereMetas(array|string|null $value)
+ * @method $this whereMetas(array<array-key, mixed>|string|null $value)
  * @method $this whereCreatedAt(\Illuminate\Support\Carbon|string $value)
  * @method $this whereUpdatedAt(\Illuminate\Support\Carbon|string $value)
  * @method $this whereDeletedAt(\Illuminate\Support\Carbon|string|null $value)


### PR DESCRIPTION
This pull request introduces enhancements to type handling and documentation generation in the `NextIdeHelper` package, with a focus on improving compatibility with Larastan. Key changes include the addition of a `Generics` helper class for managing generic type annotations, updates to type resolution logic, and modifications to generated model docblocks for better type specificity.

### Type Handling Enhancements:
* [`src/Domain/Models/AttributeTypeCaster.php`](diffhunk://#diff-0520a4f339cf47a9e24ca182529ca81cb5f600aea06489a5a6426f8cd91d6744L89-R109): Updated `resolveFromCast` and `resolveCastable` methods to use the new `Generics` helper for generating generic type annotations, improving type specificity for arrays, collections, and other castable attributes. [[1]](diffhunk://#diff-0520a4f339cf47a9e24ca182529ca81cb5f600aea06489a5a6426f8cd91d6744L89-R109) [[2]](diffhunk://#diff-0520a4f339cf47a9e24ca182529ca81cb5f600aea06489a5a6426f8cd91d6744L202-R230)

### Documentation Generation Improvements:
* [`src/Domain/Models/Output/Generics.php`](diffhunk://#diff-960d38e9b21f67f38842fc803d11a93a6284048634443d52a4ca669a77f8e66dR1-R27): Introduced the `Generics` helper class to manage generic type annotations based on configuration settings.
* [`src/Domain/Models/Output/ModelDocBlock.php`](diffhunk://#diff-71f61efc217829d3b35d88c1e009bfadb06fa7f6832b5555affaa3b44d0988c4L152-R152): Refactored methods like `query`, `all`, and `queryMixin` to use `Generics::get` for generating Larastan-friendly comments, and removed redundant `larastanFriendly` logic. [[1]](diffhunk://#diff-71f61efc217829d3b35d88c1e009bfadb06fa7f6832b5555affaa3b44d0988c4L152-R152) [[2]](diffhunk://#diff-71f61efc217829d3b35d88c1e009bfadb06fa7f6832b5555affaa3b44d0988c4L166-R163) [[3]](diffhunk://#diff-71f61efc217829d3b35d88c1e009bfadb06fa7f6832b5555affaa3b44d0988c4L180-R174) [[4]](diffhunk://#diff-71f61efc217829d3b35d88c1e009bfadb06fa7f6832b5555affaa3b44d0988c4L210-L214)
* [`src/Domain/Models/Output/QueryBuilderDocBlock.php`](diffhunk://#diff-f16e2767b06e96839ae1c80fc324e522f2c2fb9041106f4f4d73a245250feb11L50-R50): Updated methods to use `Generics::get` for type annotations and removed the `larastanFriendly` method. [[1]](diffhunk://#diff-f16e2767b06e96839ae1c80fc324e522f2c2fb9041106f4f4d73a245250feb11L50-R50) [[2]](diffhunk://#diff-f16e2767b06e96839ae1c80fc324e522f2c2fb9041106f4f4d73a245250feb11L115-R115) [[3]](diffhunk://#diff-f16e2767b06e96839ae1c80fc324e522f2c2fb9041106f4f4d73a245250feb11L166-L170)

### Snapshot Updates for Larastan Compatibility:
* [`tests/.pest/snapshots/Feature/ModelsCommandTest`](diffhunk://#diff-1a1fd4ab6fa2c703fcb1eccb9d650c2a39bf1d1386db36f496b3d0ba6895ec58L21-R21): Adjusted generated snapshots to include Larastan-friendly type annotations for properties and methods, such as `array<array-key, mixed>` and `array<array-key, mixed>|string|null`. [[1]](diffhunk://#diff-1a1fd4ab6fa2c703fcb1eccb9d650c2a39bf1d1386db36f496b3d0ba6895ec58L21-R21) [[2]](diffhunk://#diff-b727dde4e3e0ccd4c797804d996dde6e7e13bddfcdb3c7b522070dd29c301bf1L17-R17) [[3]](diffhunk://#diff-c3043b9dfebc8f89ab7da6659d347983c167032a5bd97312fb9cebbcc1c09fdcL15-R15)